### PR TITLE
fix syntax error in code example

### DIFF
--- a/src/content/6/en/part6c.md
+++ b/src/content/6/en/part6c.md
@@ -387,7 +387,7 @@ const App = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(initializeNotes()))  
+    dispatch(initializeNotes())  
   }, [dispatch]) 
 
   // ...


### PR DESCRIPTION
invalid closing parenthesis