### PR TITLE
fix syntax error in code example

### DIFF
--- a/src/content/6/es/part6c.md
+++ b/src/content/6/es/part6c.md
@@ -320,7 +320,7 @@ const App = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(initializeNotes()))  
+    dispatch(initializeNotes())  
   },[dispatch]) 
 
   // ...


### PR DESCRIPTION
invalid closing parenthesis