### PR TITLE
fix syntax error in code example

### DIFF
--- a/src/content/6/zh/part6c.md
+++ b/src/content/6/zh/part6c.md
@@ -420,7 +420,7 @@ const App = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(initializeNotes()))
+    dispatch(initializeNotes())
   },[dispatch])
 
   // ...


### PR DESCRIPTION
invalid closing parenthesis